### PR TITLE
User search does not work against CROWD 2.10.1

### DIFF
--- a/src/main/java/org/sonatype/nexus/plugins/crowd/client/rest/jaxb/GroupResponse.java
+++ b/src/main/java/org/sonatype/nexus/plugins/crowd/client/rest/jaxb/GroupResponse.java
@@ -10,6 +10,9 @@
  */
 package org.sonatype.nexus.plugins.crowd.client.rest.jaxb;
 
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlRootElement;
 
@@ -18,6 +21,13 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 @XmlRootElement(name="group")
 public class GroupResponse {
+    /**
+     * Capture any unknown elements that might be returned by newer crowd REST API versions, 
+     * thus avoiding exceptions during JAXB unmarshalling
+     */
+    @XmlAnyElement(lax = true)
+    protected List<Object> any;
+
     @XmlAttribute
     public String name;
 

--- a/src/main/java/org/sonatype/nexus/plugins/crowd/client/rest/jaxb/UserResponse.java
+++ b/src/main/java/org/sonatype/nexus/plugins/crowd/client/rest/jaxb/UserResponse.java
@@ -10,6 +10,9 @@
  */
 package org.sonatype.nexus.plugins.crowd.client.rest.jaxb;
 
+import java.util.List;
+
+import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -19,6 +22,13 @@ import javax.xml.bind.annotation.XmlRootElement;
  */
 @XmlRootElement(name="user")
 public class UserResponse {
+    /**
+     * Capture any unknown elements that might be returned by newer crowd REST API versions, 
+     * thus avoiding exceptions during JAXB unmarshalling
+     */
+    @XmlAnyElement(lax = true)
+    protected List<Object> any;
+
     @XmlAttribute
     public String name;
 


### PR DESCRIPTION
https://github.com/PatrickRoumanoff/nexus-crowd-plugin/issues/26
Added @XmlAnyElement(lax = true) to all response classes, so JAXB does
not throw an exception during deserialization. This might happen when
new attributes are added to the CROWD rest response as part of newer
CROWD REST API releases.